### PR TITLE
exec gnomegmail.py from launcher script and use its shebang

### DIFF
--- a/gnome-gmail
+++ b/gnome-gmail
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-python /usr/share/gnome-gmail/gnomegmail.py "$@"
+exec /usr/share/gnome-gmail/gnomegmail.py "$@"
 


### PR DESCRIPTION
Two benefits here: no persistent shell kept around (exec), and one less place where the python interpreter is specified.