### PR TITLE
Fix glade file lookup

### DIFF
--- a/gnomegmail.py
+++ b/gnomegmail.py
@@ -761,12 +761,7 @@ def main():
                 header=header,
              )
 
-    # anyone know how to do this right?
-    glade_suffix = "/share/gnome-gmail/gnomegmail.glade"
-    glade_file = os.path.join('/usr', glade_suffix)
-    for gpath in [os.path.join(x, glade_suffix) for x in ['/usr/local']]:
-        if os.path.isfile(gpath):
-            glade_file = gpath
+    glade_file = os.path.join(os.path.dirname(__file__), "gnomegmail.glade")
 
     if not is_default_mailer() \
             and not config.get_bool('suppress_preferred'):


### PR DESCRIPTION
Previously, lookup from a few prefixes was attempted, but the leading slash in "/share/gnome-gmail/..." made it not to work:

```python
>>> import os
>>> os.path.join("/usr", "/share/gnome-gmail/gnomegmail.glade")
'/share/gnome-gmail/gnomegmail.glade'
```

The whole prefix lookup seems unnecessary. Simply loading from the same dir as gnomegmail.py fixes the above and additionally makes running in-tree easier.