### PR TITLE
Fix order of releases in appdata

### DIFF
--- a/gnome-gmail.appdata.xml.in
+++ b/gnome-gmail.appdata.xml.in
@@ -47,11 +47,11 @@ page will be used whenever an email service is requested.</_p>
 </screenshots>
 <releases>
     <!-- Get timestamp with 'date +%s' -->
-    <release version="2.0" timestamp="1450790604"></release>
-    <release version="2.0.1" timestamp="1451180280"></release>
-    <release version="2.1" timestamp="1464383933"></release>
-    <release version="2.2" timestamp="1467166565"></release>
-    <release version="2.3" timestamp="1483500463"></release>
     <release version="2.3.1" timestamp="1483845277"></release>
+    <release version="2.3" timestamp="1483500463"></release>
+    <release version="2.2" timestamp="1467166565"></release>
+    <release version="2.1" timestamp="1464383933"></release>
+    <release version="2.0.1" timestamp="1451180280"></release>
+    <release version="2.0" timestamp="1450790604"></release>
 </releases>
 </component>


### PR DESCRIPTION
```
$ appstream-util validate-relax gnome-gmail.appdata.xml.in 
gnome-gmail.appdata.xml.in: FAILED:
• tag-invalid           : <release> versions are not in order [2.0 before 2.0.1]
• tag-invalid           : <release> versions are not in order [2.0.1 before 2.1]
• tag-invalid           : <release> versions are not in order [2.1 before 2.2]
• tag-invalid           : <release> versions are not in order [2.2 before 2.3]
• tag-invalid           : <release> versions are not in order [2.3 before 2.3.1]
• tag-invalid           : <release> timestamps are not in order [1450790604 before 1451180280]
• tag-invalid           : <release> timestamps are not in order [1451180280 before 1464383933]
• tag-invalid           : <release> timestamps are not in order [1464383933 before 1467166565]
• tag-invalid           : <release> timestamps are not in order [1467166565 before 1483500463]
• tag-invalid           : <release> timestamps are not in order [1483500463 before 1483845277]
Validation of files failed
```