### PR TITLE
Fail OAuth gracefully when default screen cannot be accessed

### DIFF
--- a/gnomegmail.py
+++ b/gnomegmail.py
@@ -210,6 +210,8 @@ class GMOauth():
         while time.time() - now < 120:
             Gtk.main_iteration()
             screen = Wnck.Screen.get_default()
+            if screen is None:  # Possible in non-X11, e.g. Wayland
+                raise GGError(_("Could not access default screen"))
             screen.force_update()
 
             for win in screen.get_windows():


### PR DESCRIPTION
Wnck.Screen.get_default may return None on non-X11, e.g. Wayland; this happens for me in Fedora 25. Would be nice to get things working with Wayland as well, but I think this is better than the unexplained traceback.