### PR TITLE
Fix send_mail on Python 3

### DIFF
--- a/gnomegmail.py
+++ b/gnomegmail.py
@@ -456,9 +456,9 @@ class GMailAPI():
             raise GGError(_("Error returned from the GMail API - %s - %s") %
                           (e.code, e.msg))
 
-        result = urlfp.fp.read().decode('utf-8')
+        result = urlfp.fp.read()
         self.resource = result
-        json_result = json.loads(result)
+        json_result = json.loads(result.decode('utf-8'))
         id = json_result['message']['id']
 
         return id


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/share/gnome-gmail/gnomegmail.py", line 928, in <module>
    main()
  File "/usr/share/gnome-gmail/gnomegmail.py", line 912, in main
    gmailurl = gm_url.gmail_url(args.send)
  File "/usr/share/gnome-gmail/gnomegmail.py", line 602, in gmail_url
    gmailurl = self.api_gmail_url(send)
  File "/usr/share/gnome-gmail/gnomegmail.py", line 590, in api_gmail_url
    gm_api.send_mail(self.from_address, access)
  File "/usr/share/gnome-gmail/gnomegmail.py", line 482, in send_mail
    urlfp = opener.open(request)
  File "/usr/lib64/python3.5/urllib/request.py", line 464, in open
    req = meth(req)
  File "/usr/lib64/python3.5/urllib/request.py", line 1183, in do_request_
    raise TypeError(msg)
TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.

```