### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ gnome-gmail (2.7-2) UNRELEASED; urgency=medium
   * Set fields Upstream-Contact in debian/copyright.
   * Remove obsolete fields Name, Contact from debian/upstream/metadata.
   * Wrap long lines in changelog entries: 1.7.3.
+  * Set upstream metadata fields: Bug-Submit.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 18 Sep 2019 11:48:10 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ gnome-gmail (2.7-2) UNRELEASED; urgency=medium
   * Re-export upstream signing key without extra signatures.
   * Set fields Upstream-Contact in debian/copyright.
   * Remove obsolete fields Name, Contact from debian/upstream/metadata.
+  * Wrap long lines in changelog entries: 1.7.3.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 18 Sep 2019 11:48:10 +0000
 
@@ -302,7 +303,8 @@ gnome-gmail (1.7.3) unstable; urgency=low
 
   * Switch to native package as debian/ is maintained upstream
   * Add libgconf2-dev, autotools-dev, and dh-autoreconf to Build-Depends
-  * Migrate to simplified dh based debian/rules (these last two changes fixes a FTBFS)
+  * Migrate to simplified dh based debian/rules (these last two changes fixes a
+    FTBFS)
   * Include the non-Debian changelog in the package
 
  -- Michael R. Crusoe <michael.crusoe@gmail.com>  Tue, 29 Mar 2011 13:40:36 -0700

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,4 @@
+Bug-Submit: https://github.com/davesteele/gnome-gmail/issues/new
 Homepage: https://davesteele.github.io/gnome-gmail/
 Bug-Database: https://github.com/davesteele/gnome-gmail/issues
 Screenshots: https://davesteele.github.io/gnome-gmail/screenshots.html


### PR DESCRIPTION
Fix some issues reported by lintian
* Wrap long lines in changelog entries: 1.7.3. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))
* Set upstream metadata fields: Bug-Submit. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/gnome-gmail/1c53cb63-53aa-4e7a-b6a5-d13daf4b5a96.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/1c53cb63-53aa-4e7a-b6a5-d13daf4b5a96/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1c53cb63-53aa-4e7a-b6a5-d13daf4b5a96/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1c53cb63-53aa-4e7a-b6a5-d13daf4b5a96/diffoscope)).
