### PR TITLE
Create --user option

### DIFF
--- a/gnome-gmail.1
+++ b/gnome-gmail.1
@@ -5,7 +5,7 @@
 .SH NAME
 gnome-gmail \- Integrate GMail into the GNOME desktop
 .SH SYNOPSIS
-\fBgnome-gmail\fP [\fB\-r\fP \fIfile\fP|\fI<mailto-URL>\fP] [\fB\-\-send\fP]
+\fBgnome-gmail\fP [\fB\-r\fP \fIfile\fP|\fI<mailto-URL>\fP] [\fB\-\-send\fP] [\fB\-u\fP \fI<user-email>\fP|\fB\-\-user\fP \fI<user-email>\fP]
 .SH DESCRIPTION
 The \fBgnome-gmail\fP script opens a GMail page on the default web browser, with a message composed according
 to the supplied RFC2368 \fImailto:\fP URL. This script is used to support GMail as a GNOME Preferred Application for email.
@@ -16,6 +16,9 @@ not well formed, it is assumed to be the recipient. If no argument is supplied, 
 .TP
 .B \-s, \-\-send
 send immediately
+.B \-u, \-\-user
+open the application with user email already choosen
+.TP
 .TP
 .B \-r \fIfile\fP, \-\-rfc \fIfile\fP
 send the RFC822-formatted file \fIfile\fP

--- a/gnomegmail.py
+++ b/gnomegmail.py
@@ -876,7 +876,7 @@ def do_preferred(glade_file, config):
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Send mail via the Gmail API and the browser interface.",
-        usage="%(prog)s [-h|-q|[-s] <mailto>]",
+        usage="%(prog)s [-h|-q|[-s [-u] <mailto>]",
         epilog=textwrap.dedent("""\
             The gnome-gmail utility will create an email message from the
             mailto argument, upload it to Gmail using the Gmail API, and open
@@ -914,6 +914,12 @@ def parse_args():
         metavar="file",
         default=None,
         help="upload an RFC822-formatted message",
+    )
+
+    parser.add_argument(
+        '-u', '--user',
+        default=None,
+        help="User from email"
     )
 
     args = parser.parse_args()
@@ -992,7 +998,9 @@ def main():
 
     from_address = None
     message = None
-    if args.rfc822:
+    if args.user:
+        from_address = args.user
+    elif args.rfc822:
         message = open(args.rfc822, 'r').read()
         from_address = fromFromMessage(message)
     else:


### PR DESCRIPTION
Create a --user option to specify how email will be chosen, taking away the need to open the pop up. 

The reason for creating this feature is a need to have a way to open the client already specifying the email, so is this way we can create specific shortcuts for each email, for example:

A shortcut to open `gnome-gmail --user omarkdev@gmail.com`